### PR TITLE
Factor out the code from the TXT into a proper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Oprendszerek Beadandó
+
+## Requirements
+
+* NPM
+
+
+## Before submission
+
+To submit a valid project work, `dokumentacio.pdf` has to be generated.
+
+
+On GNU/Linux execute:
+
+```sh
+$ ./md-konvertalas-pdf
+```
+
+On other operating systems:
+1. Install the NPM package `md-to-pdf` globally (`npm install -g md-to-pdf`)
+1. Run `md2pdf dokumentacio.md` in the root of the project 
+

--- a/md-konvertalas-pdf.sh
+++ b/md-konvertalas-pdf.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if ! command -v md2pdf &> /dev/null
+then
+    echo "md-to-pdf is not installed. Installing..."
+    npm install -g md-to-pdf
+fi
+
+md2pdf dokumentacio.md
+

--- a/md-konvertalas-pdf.txt
+++ b/md-konvertalas-pdf.txt
@@ -1,4 +1,0 @@
-#0. npm-mel feltelepíteni a md-to-pdf packaget
-npm i g md-to-pdf
-#1. md2pdf futtatása (oprendszerek_beadando mappán belül)
-md2pdf dokumentacio.md


### PR DESCRIPTION
## Description

Currently, we have [md-konvertalas-pdf.txt](https://github.com/nagytoth1/oprendszerek_beadando/blob/0a865bdc716236a4b3aecf360741fc70f775031b/md-konvertalas-pdf.txt), which is hard to find.

Steps/instructions usually go into `README.md` files.

## Contents

This PR aims to

* create a README file with the steps to produce a PDF from the raw documentation files;
* provide a script for Linux users

## Notes

Take it or close it, it's just a suggestion.